### PR TITLE
Na brmo 1.6.4-SNAPSHOT bestaan de niet-materialized views niet meer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <test.skipTs>false</test.skipTs>
         <test.skipITs>true</test.skipITs>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
-        <brmo.version>1.6.3p1</brmo.version>
+        <brmo.version>1.6.4-SNAPSHOT</brmo.version>
         <tomcat.version>7.0.96</tomcat.version>
         <postgresql.jdbc.version>42.2.8</postgresql.jdbc.version>
         <slf4j.version>1.8.0-beta4</slf4j.version>

--- a/src/main/java/nl/b3p/brmo/verschil/stripes/MutatiesActionBean.java
+++ b/src/main/java/nl/b3p/brmo/verschil/stripes/MutatiesActionBean.java
@@ -105,19 +105,19 @@ public class MutatiesActionBean implements ActionBean, ValidationErrorHandler {
      *
      * @see #initParams()
      */
-    private String VIEW_KOZ_RECHTHEBBENDE = "vb_koz_rechth";
+    private String VIEW_KOZ_RECHTHEBBENDE = "mb_koz_rechth";
     /**
      * context param voor view vb_kad_onrrnd_zk_adres.
      *
      * @see #initParams()
      */
-    private String VIEW_KAD_ONRRND_ZK_ADRES = "vb_kad_onrrnd_zk_adres";
+    private String VIEW_KAD_ONRRND_ZK_ADRES = "mb_kad_onrrnd_zk_adres";
     /**
      * context param voor view vb_kad_onrrnd_zk_archief.
      *
      * @see #initParams()
      */
-    private String VIEW_KAD_ONRRND_ZK_ARCHIEF = "vb_kad_onrrnd_zk_archief";
+    private String VIEW_KAD_ONRRND_ZK_ARCHIEF = "mb_kad_onrrnd_zk_archief";
     /**
      * context param voor sql JDBC_FETCH_SIZE.
      *
@@ -907,16 +907,6 @@ public class MutatiesActionBean implements ActionBean, ValidationErrorHandler {
     }
 
     private void initParams() {
-        boolean use_mv = Boolean.parseBoolean(getContext().getServletContext().getInitParameter("use_mv"));
-        if (use_mv) {
-            LOG.info("Gebruik materialized views in de queries.");
-            VIEW_KOZ_RECHTHEBBENDE = VIEW_KOZ_RECHTHEBBENDE.replaceFirst("vb_", "mb_");
-            VIEW_KAD_ONRRND_ZK_ADRES = VIEW_KAD_ONRRND_ZK_ADRES.replaceFirst("vb_", "mb_");
-            VIEW_KAD_ONRRND_ZK_ARCHIEF = VIEW_KAD_ONRRND_ZK_ARCHIEF.replaceFirst("vb_", "mb_");
-        } else {
-            LOG.warn("Gebruik reguliere views in de queries (zeer langzaam).");
-        }
-
         try {
             JDBC_FETCH_SIZE = Integer.parseInt(getContext().getServletContext().getInitParameter("jdbc_fetch_size"));
             LOG.info(String.format("Gebruik fetch size van: %s records", JDBC_FETCH_SIZE));

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -7,8 +7,6 @@
            digest="SHA-1">
         <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler" algorithm="SHA-1"/>
     </Realm>
-    <!-- true (default) om materialized views te gebruiken in de queries -->
-    <Parameter description="true om materialized views te gebruiken in de queries" name="use_mv" value="true" override="false"/>
     <!-- query timout cvoor database queries in seconden, default is 600 sec -->
     <Parameter description="database query timeout" name="jdbc_query_timeout" value="600" override="false"/>
     <!-- database recordset fetch size hint, default 0 -->


### PR DESCRIPTION
Na https://github.com/B3Partners/brmo/pull/617 bestaan de niet-materialized views niet meer.
Dit haalt de optie om te kiezen weg.

ik denk dat er op kolom nivo niet zoveel is aangepast, 
Toegevoegd zijn datum kolommen als `datetime` (bijv. begin_geldigheid_datum in MB_KAD_ONRRND_ZK_ARCHIEF), niet gechecked of daar ook een goeie index op zit voor window queries, lijkt niet zo te zijn... mogelijk een GiST index op zetten voor daterange queries

https://github.com/B3Partners/brmo/blob/bcda6eba83165bfa9be8a6e751caead536675a54/datamodel/extra_scripts/postgresql/207_brk_views.sql#L1362-L1396


