### PR TITLE
Bump com.fasterxml.jackson.core:jackson-databind to 2.9.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10</version>
+            <version>2.9.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.stripesstuff</groupId>


### PR DESCRIPTION
resolves CVE-2019-16942